### PR TITLE
Fixing: Adding CorsConfiguration

### DIFF
--- a/src/main/java/com/valdir/bookstore/config/CorsConfiguration.java
+++ b/src/main/java/com/valdir/bookstore/config/CorsConfiguration.java
@@ -1,0 +1,22 @@
+package com.valdir.bookstore.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfiguration {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD", "TRACE", "CONNECT");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
Problema: from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

Olá, enquanto eu estava tentandor puxar os dados de uma api e exibir o Json na tela via console log recebo o seguinte erro:

```
Access to XMLHttpRequest at 'https://api-product-list.herokuapp.com/Product-List' from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

GET https://api-product-list.herokuapp.com/Product-List net::ERR_FAILED
(anonymous) @ consuming.js:10
```

No  console do chrome e outros navegadores, tive o mesmo resultado. Para solucionar o meu problema apenas configurei o Cors na API. 

## Todos
- [] Tests
- [] Documentation

## Deploy notes

## Steps to Test or Reproduce

```sh
mvn spring-boot:run
```